### PR TITLE
Fixes for starting world and simple builder

### DIFF
--- a/mud/home/Game/initd.c
+++ b/mud/home/Game/initd.c
@@ -118,8 +118,8 @@ void build_world()
 	object trinket;
 
 	world = create_thing();
-	world->set_object_name("world");
-	world->set_id("world");
+	world->set_object_name("planets:earth");
+	world->set_id("earth");
 	world->set_mass(5.972e+24);
 	world->set_density(6.5);
 	world->set_capacity(1e+12);
@@ -128,7 +128,7 @@ void build_world()
 		USR_DIR + "/Game/sys/handler/paint/fill/grass");
 
 	world->add_local_detail(nil);
-	world->set_local_snouns(nil, ({ "world" }) );
+	world->set_local_snouns(nil, ({ "planet" }) );
 
 	master = create_thing();
 	master->set_object_name("class:race:humanoid:human");

--- a/mud/home/Text/obj/ustate/wiz/simplebuild.c
+++ b/mud/home/Text/obj/ustate/wiz/simplebuild.c
@@ -196,7 +196,7 @@ private void do_makeroom()
 	room->set_capacity((float)(sx * sy * 3));
 	room->set_max_mass((float)(sx * sy * 1000));
 
-	creator = new_object("objcreate");
+	creator = query_user()->clone_ustate("wiz/objcreate");
 	creator->set_object(room);
 
 	room = nil;

--- a/mud/home/Verb/sys/verb/ic/combat/reincarnate.c
+++ b/mud/home/Verb/sys/verb/ic/combat/reincarnate.c
@@ -107,7 +107,7 @@ void main(object actor, mapping roles)
 		return;
 	}
 
-	world = IDD->find_object_by_name("planets:aerth");
+	world = IDD->find_object_by_name("planets:earth");
 
 	if (!world) {
 		send_out("BUG: Starting world not found, yell at a wizard.\n");

--- a/mud/home/Verb/sys/verb/ooc/charfix.c
+++ b/mud/home/Verb/sys/verb/ooc/charfix.c
@@ -156,7 +156,7 @@ void main(object actor, mapping roles)
 
 		send_out("Your body was nowhere.\n");
 
-		world = IDD->find_object_by_name("planets:aerth");
+		world = IDD->find_object_by_name("planets:earth");
 
 		if (!world) {
 			send_out("The start world is missing, yell at a wizard!\n");

--- a/mud/home/Verb/sys/verb/ooc/chargen.c
+++ b/mud/home/Verb/sys/verb/ooc/chargen.c
@@ -66,14 +66,14 @@ void main(object actor, mapping roles)
 		return;
 	}
 
-	world = IDD->find_object_by_name("planets:aerth");
+	world = IDD->find_object_by_name("planets:earth");
 
 	if (!world) {
 		send_out("BUG: Starting world not found, yell at a wizard.\n");
 		return;
 	}
 
-	human = IDD->find_object_by_name("class:race:human");
+	human = IDD->find_object_by_name("class:race:humanoid:human");
 
 	if (!human) {
 		send_out("BUG: human race not found, yell at a wizard.\n");


### PR DESCRIPTION
Changes:

* Changed the world creation code to create the `planets:earth` object.
* Changed the code in character related verbs  to fix the typo.
* Fixed an error in the `simplebuild` ustate regarding room creation, not sure if there are other errors.